### PR TITLE
Add group control item APIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ pip install -r requirements.txt
 | `POST /api/script/add` | 複数セリフを一括追加（文字数から長さ自動計算） |
 | `POST /api/item/edit` | アイテムのプロパティを変更 |
 | `POST /api/item/delete` | アイテムを削除（layer+frame指定） |
+| `POST /api/items/group-control` | YMM4 のグループ制御アイテムを frame/layer/length に追加。group / sameGroupOnly / layerRange は内部プロパティが見つかった場合に設定 |
+| `POST /api/items/group/add` | targets の frame/layer に一致する既存アイテムへ group 相当プロパティを付与・変更 |
+| `GET  /api/debug/group` | Group / GroupControl / グループ制御 関連の型、メソッド、プロパティ候補を列挙 |
 
 ### 映像確認系
 | エンドポイント | 説明 |
@@ -139,13 +142,18 @@ pip install -r requirements.txt
 | `get_info` | `project` | プロジェクト情報取得 |
 | `get_info` | `items` | タイムライン全アイテム取得 |
 | `get_info` | `effects_list` | エフェクト一覧 |
+| `get_info` | `group_debug` | `/api/debug/group` から group 関連の内部 API 候補を取得 |
 | `control` | `play` | 再生 |
 | `control` | `stop` | 停止 |
 | `control` | `save` | 保存 |
 | `add_item` | `voice` | セリフ1件追加 |
+| `add_item` | `group_control` | グループ制御アイテムを追加。frame, layer, length, group, sameGroupOnly, layerRange を指定 |
 | `add_script` | —— | 複数セリフ一括追加（文字数→フレーム自動計算） |
 | `edit_item` | `property` | フレーム位置・長さ等を変更 |
+| `edit_item` | `group` | targets の frame/layer に一致する既存アイテムの group 設定を変更 |
 | `edit_item` | `delete` | アイテム削除 |
+
+注意: グループ制御と group 設定は YMM4 内部 API に依存します。YMM4 のバージョンによって型名、メソッド名、プロパティ名が異なる可能性があるため、実機環境では `GET /api/debug/group` または `action="get_info", sub_action="group_debug"` で候補を確認してから動作確認してください。
 
 **add_scriptのパラメータ：**
 ```python

--- a/README.md
+++ b/README.md
@@ -114,6 +114,14 @@ pip install -r requirements.txt
 | `POST /api/items/group-control` | YMM4 のグループ制御アイテムを frame/layer/length に追加。group / sameGroupOnly / layerRange は内部プロパティが見つかった場合に設定 |
 | `POST /api/items/group/add` | targets の frame/layer に一致する既存アイテムへ group 相当プロパティを付与・変更 |
 | `GET  /api/debug/group` | Group / GroupControl / グループ制御 関連の型、メソッド、プロパティ候補を列挙 |
+| `GET  /api/debug/item` | `frame` / `layer` / `type` に一致するアイテムのプロパティを浅く列挙。group-control beta 検証用 |
+
+Beta note: group-control motion fields are experimental. `/api/items/group-control`
+accepts optional `x`, `y`, `zoom`, `scale`, `rotation`, `opacity` arrays such as
+`"x":[0,-100]`, plus `repeat:true`, but YMM4 internal property names differ by
+version. The API applies any matching properties it can find and reports failures
+per field. Use `GET /api/debug/group` and `GET /api/debug/item?frame=...&layer=...`
+when verifying a YMM4 version.
 
 ### 映像確認系
 | エンドポイント | 説明 |
@@ -154,6 +162,10 @@ pip install -r requirements.txt
 | `edit_item` | `delete` | アイテム削除 |
 
 注意: グループ制御と group 設定は YMM4 内部 API に依存します。YMM4 のバージョンによって型名、メソッド名、プロパティ名が異なる可能性があるため、実機環境では `GET /api/debug/group` または `action="get_info", sub_action="group_debug"` で候補を確認してから動作確認してください。
+
+Beta note: MCP `add_item/group_control` also forwards optional `x`, `y`, `zoom`,
+`scale`, `rotation`, `opacity`, and `repeat` fields. Treat this as beta-level
+support until each target YMM4 version has been verified.
 
 **add_scriptのパラメータ：**
 ```python

--- a/YMM4McpPlugin/McpHttpServer.cs
+++ b/YMM4McpPlugin/McpHttpServer.cs
@@ -125,6 +125,7 @@ namespace YMM4McpPlugin
                     ("GET", "/api/debug/tachie/props") => DebugTachieItemProps(),
                     ("GET", "/api/debug/facetypes") => DebugFaceTypes(),
                     ("GET", "/api/debug/voiceitem/props") => DebugVoiceItemProps(),
+                    ("GET", "/api/debug/item") => DebugItem(req),
                     ("POST", "/api/items/effect/audio") => await AddAudioEffect(req),
                     ("GET", "/api/debug/visualtree") => DebugVisualTree(req),
                     ("GET", "/api/debug/player") => DebugPlayer(),
@@ -460,6 +461,9 @@ namespace YMM4McpPlugin
             int group = GetInt(b, "group", 0);
             bool sameGroupOnly = GetBool(b, "sameGroupOnly", true);
             int layerRange = GetInt(b, "layerRange", 0);
+            // BETA: GroupItem internals vary by YMM4 version. These optional motion
+            // fields use broad reflection aliases and report per-field success/failure.
+            var motion = GetGroupMotionSpec(b);
 
             return Application.Current.Dispatcher.Invoke(() =>
             {
@@ -467,17 +471,17 @@ namespace YMM4McpPlugin
                 var tvm = GetPropObj(vm, "ActiveTimelineViewModel"); if (tvm == null) return (object)new { success = false, error = "TVM失敗" };
                 var mainModel = GetMainModel(vm);
                 var timelineObj = GetTimelineObject(vm, tvm);
-                var candidates = GetGroupDebugPayload(vm, tvm, mainModel, timelineObj);
+                object Candidates() => GetGroupDebugPayload(vm, tvm, mainModel, timelineObj);
 
                 var type = FindGroupControlType();
                 if (type == null)
-                    return (object)new { success = false, error = "グループ制御アイテム型が見つかりません", candidates };
+                    return (object)new { success = false, error = "グループ制御アイテム型が見つかりません", candidates = Candidates() };
 
                 object? item = null;
                 try
                 {
                     item = CreateBestEffort(type, frame, layer, length, group, sameGroupOnly, layerRange);
-                    if (item == null) return (object)new { success = false, error = "グループ制御アイテムを生成できません", type = type.FullName, constructors = DescribeConstructors(type), candidates };
+                    if (item == null) return (object)new { success = false, error = "グループ制御アイテムを生成できません", type = type.FullName, constructors = DescribeConstructors(type), candidates = Candidates() };
 
                     var propResults = new List<object>
                     {
@@ -485,19 +489,20 @@ namespace YMM4McpPlugin
                         TrySetAnyProp(item, new[] { "Layer" }, layer),
                         TrySetAnyProp(item, new[] { "Length", "Duration" }, length),
                         TrySetAnyProp(item, GroupPropNames, group),
-                        TrySetAnyProp(item, new[] { "SameGroupOnly", "IsSameGroupOnly", "TargetSameGroupOnly", "同じグループのみ" }, sameGroupOnly),
-                        TrySetAnyProp(item, new[] { "LayerRange", "Range", "TargetLayerRange", "対象レイヤー数", "レイヤー範囲" }, layerRange)
+                        TrySetAnyProp(item, new[] { "SameGroupOnly", "IsSameGroupOnly", "IsGroupOnly", "TargetSameGroupOnly", "同じグループのみ" }, sameGroupOnly),
+                        TrySetAnyProp(item, new[] { "LayerRange", "GroupRange", "Range", "TargetLayerRange", "対象レイヤー数", "レイヤー範囲" }, layerRange)
                     };
+                    propResults.AddRange(ApplyGroupMotion(item, motion));
 
                     var addResult = TryAddTimelineItem(vm, tvm, mainModel, timelineObj, item, frame, layer, length, group, sameGroupOnly, layerRange);
                     if (!addResult.Success)
-                        return (object)new { success = false, error = addResult.Error, type = type.FullName, properties = propResults, add = addResult.Detail, candidates };
+                        return (object)new { success = false, error = addResult.Error, type = type.FullName, properties = propResults, add = addResult.Detail, candidates = Candidates() };
 
                     return (object)new { success = true, type = type.FullName, frame, layer, length, group, sameGroupOnly, layerRange, add = addResult.Detail, properties = propResults };
                 }
                 catch (Exception ex)
                 {
-                    return (object)new { success = false, error = ex.InnerException?.Message ?? ex.Message, type = type.FullName, candidates };
+                    return (object)new { success = false, error = ex.InnerException?.Message ?? ex.Message, type = type.FullName, candidates = Candidates() };
                 }
             });
         }
@@ -1489,18 +1494,173 @@ namespace YMM4McpPlugin
 
         private static Type? FindGroupControlType()
         {
-            return GetLoadedTypes()
+            var types = GetLoadedTypes()
                 .Where(t => !t.IsAbstract && !t.IsInterface && !t.IsEnum && IsGroupControlRelated(t.Name, t.FullName))
+                .ToArray();
+
+            return types
+                .FirstOrDefault(t => t.FullName == "YukkuriMovieMaker.Project.Items.GroupItem")
+                ?? types
+                .Where(t => t.Namespace?.StartsWith("YukkuriMovieMaker.Project.Items", StringComparison.Ordinal) == true)
+                .OrderByDescending(t => t.Name.Equals("GroupItem", StringComparison.OrdinalIgnoreCase))
+                .ThenByDescending(t => t.Name.Contains("Item", StringComparison.OrdinalIgnoreCase))
+                .FirstOrDefault()
+                ?? types
                 .OrderByDescending(t => t.Name.Contains("Item", StringComparison.OrdinalIgnoreCase))
                 .FirstOrDefault();
         }
 
         private static bool IsGroupControlRelated(string name, string? fullName)
         {
-            return name.Contains("GroupControl", StringComparison.OrdinalIgnoreCase)
+            return name.Equals("GroupItem", StringComparison.OrdinalIgnoreCase)
+                || fullName == "YukkuriMovieMaker.Project.Items.GroupItem"
+                || name.Contains("GroupControl", StringComparison.OrdinalIgnoreCase)
                 || (fullName?.Contains("GroupControl", StringComparison.OrdinalIgnoreCase) == true)
                 || name.Contains("グループ制御")
                 || (fullName?.Contains("グループ制御") == true);
+        }
+
+        private sealed record GroupMotionSpec(
+            (double? From, double? To)? X,
+            (double? From, double? To)? Y,
+            (double? From, double? To)? Zoom,
+            (double? From, double? To)? Scale,
+            (double? From, double? To)? Rotation,
+            (double? From, double? To)? Opacity,
+            bool? Repeat);
+
+        private static GroupMotionSpec GetGroupMotionSpec(Dictionary<string, JsonElement> b)
+        {
+            return new GroupMotionSpec(
+                ReadRange(b, "x", "xFrom", "xTo"),
+                ReadRange(b, "y", "yFrom", "yTo"),
+                ReadRange(b, "zoom", "zoomFrom", "zoomTo"),
+                ReadRange(b, "scale", "scaleFrom", "scaleTo"),
+                ReadRange(b, "rotation", "rotationFrom", "rotationTo"),
+                ReadRange(b, "opacity", "opacityFrom", "opacityTo"),
+                b.TryGetValue("repeat", out var repeat) ? ReadBool(repeat) : null);
+        }
+
+        private static (double? From, double? To)? ReadRange(Dictionary<string, JsonElement> b, string key, string fromKey, string toKey)
+        {
+            double? from = b.TryGetValue(fromKey, out var fe) ? ReadDouble(fe) : null;
+            double? to = b.TryGetValue(toKey, out var te) ? ReadDouble(te) : null;
+            if (b.TryGetValue(key, out var e))
+            {
+                if (e.ValueKind == JsonValueKind.Array)
+                {
+                    var vals = e.EnumerateArray().Select(ReadDouble).Where(v => v.HasValue).Select(v => v!.Value).ToArray();
+                    if (vals.Length > 0) from ??= vals[0];
+                    if (vals.Length > 1) to ??= vals[1];
+                }
+                else to ??= ReadDouble(e);
+            }
+            return from.HasValue || to.HasValue ? (from, to) : null;
+        }
+
+        private static double? ReadDouble(JsonElement e)
+        {
+            try
+            {
+                return e.ValueKind switch
+                {
+                    JsonValueKind.Number => e.GetDouble(),
+                    JsonValueKind.String when double.TryParse(e.GetString(), out var d) => d,
+                    _ => null
+                };
+            }
+            catch { return null; }
+        }
+
+        private static bool? ReadBool(JsonElement e)
+        {
+            try
+            {
+                return e.ValueKind switch
+                {
+                    JsonValueKind.True => true,
+                    JsonValueKind.False => false,
+                    JsonValueKind.String when bool.TryParse(e.GetString(), out var b) => b,
+                    _ => null
+                };
+            }
+            catch { return null; }
+        }
+
+        private static IEnumerable<object> ApplyGroupMotion(object item, GroupMotionSpec motion)
+        {
+            var results = new List<object>();
+            if (motion.X is { } x) results.Add(TrySetRangeProp(item, "x", new[] { "X", "XValue", "PositionX", "XPosition", "XParameter", "XParam" }, x.From, x.To));
+            if (motion.Y is { } y) results.Add(TrySetRangeProp(item, "y", new[] { "Y", "YValue", "PositionY", "YPosition", "YParameter", "YParam" }, y.From, y.To));
+            if (motion.Zoom is { } zoom) results.Add(TrySetRangeProp(item, "zoom", new[] { "Zoom", "ZoomValue", "ZoomParameter", "拡大率" }, zoom.From, zoom.To));
+            if (motion.Scale is { } scale) results.Add(TrySetRangeProp(item, "scale", new[] { "Scale", "ScaleX", "ScaleY", "ScaleParameter", "倍率" }, scale.From, scale.To));
+            if (motion.Rotation is { } rotation) results.Add(TrySetRangeProp(item, "rotation", new[] { "Rotation", "Angle", "Rot", "RotationParameter", "回転角" }, rotation.From, rotation.To));
+            if (motion.Opacity is { } opacity) results.Add(TrySetRangeProp(item, "opacity", new[] { "Opacity", "Alpha", "OpacityParameter", "不透明度" }, opacity.From, opacity.To));
+            if (motion.Repeat.HasValue) results.Add(TrySetAnyNestedProp(item, "repeat", new[] { "Repeat", "IsRepeat", "Loop", "IsLoop", "IsLooped", "IsRepeated", "繰り返し", "反復" }, motion.Repeat.Value));
+            return results;
+        }
+
+        private static object TrySetRangeProp(object obj, string label, string[] names, double? from, double? to)
+        {
+            foreach (var name in names)
+            {
+                var p = obj.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (p == null || p.GetIndexParameters().Length > 0) continue;
+                try
+                {
+                    var target = p.GetValue(obj);
+                    if (target != null)
+                    {
+                        bool any = false;
+                        if (from.HasValue) any |= TrySetNamedValue(target, new[] { "From", "Start", "StartValue", "Begin", "BeginValue" }, from.Value);
+                        if (to.HasValue) any |= TrySetNamedValue(target, new[] { "To", "End", "EndValue", "Value" }, to.Value);
+                        if (any) return new { success = true, motion = label, property = p.Name, from, to, mode = "nested" };
+                    }
+                    var value = to ?? from;
+                    if (value.HasValue && p.CanWrite)
+                    {
+                        p.SetValue(obj, ConvertTo(value.Value, p.PropertyType));
+                        return new { success = true, motion = label, property = p.Name, from, to, mode = "direct" };
+                    }
+                }
+                catch (Exception ex) { return new { success = false, motion = label, property = p.Name, error = ex.InnerException?.Message ?? ex.Message }; }
+            }
+            return new { success = false, motion = label, error = "property not found" };
+        }
+
+        private static object TrySetAnyNestedProp(object obj, string label, string[] names, object value)
+        {
+            if (TrySetNamedValue(obj, names, value, out var prop)) return new { success = true, motion = label, property = prop, mode = "direct" };
+            foreach (var p in obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(p => p.GetIndexParameters().Length == 0))
+            {
+                object? child = null;
+                try { child = p.GetValue(obj); } catch { }
+                if (child == null || IsSimpleType(child.GetType())) continue;
+                if (TrySetNamedValue(child, names, value, out var childProp)) return new { success = true, motion = label, property = $"{p.Name}.{childProp}", mode = "nested" };
+            }
+            return new { success = false, motion = label, error = "property not found" };
+        }
+
+        private static bool TrySetNamedValue(object obj, string[] names, object value) => TrySetNamedValue(obj, names, value, out _);
+
+        private static bool TrySetNamedValue(object obj, string[] names, object value, out string? property)
+        {
+            property = null;
+            foreach (var name in names)
+            {
+                var p = obj.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (p == null || p.GetIndexParameters().Length > 0) continue;
+                try
+                {
+                    if (TrySetPropertyValue(obj, p, value, out _))
+                    {
+                        property = p.Name;
+                        return true;
+                    }
+                }
+                catch { }
+            }
+            return false;
         }
 
         private static object GetGroupDebugPayload(object? vm, object? tvm, object? mainModel, object? timelineObj)
@@ -1605,7 +1765,13 @@ namespace YMM4McpPlugin
                 if (n.Contains("group", StringComparison.OrdinalIgnoreCase)) return group;
                 return 0;
             }
-            if (t == typeof(bool)) return n.Contains("same", StringComparison.OrdinalIgnoreCase) || sameGroupOnly;
+            if (t == typeof(bool))
+            {
+                if (n.Contains("same", StringComparison.OrdinalIgnoreCase)
+                    || n.Contains("同じ", StringComparison.OrdinalIgnoreCase))
+                    return sameGroupOnly;
+                return p.HasDefaultValue ? p.DefaultValue : false;
+            }
             if (t == typeof(string)) return "";
             if (t.IsEnum) return Enum.GetValues(t).GetValue(0);
             return p.HasDefaultValue ? p.DefaultValue : null;
@@ -1620,7 +1786,13 @@ namespace YMM4McpPlugin
 
             foreach (var target in targets)
             {
-                foreach (var method in target.GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(m => m.Name.Contains("Add") && (m.Name.Contains("Group") || m.Name.Contains("Item"))))
+                var methods = target.GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                    .Where(m => m.Name.Contains("Add") && (m.Name.Contains("Group") || m.Name.Contains("Item")))
+                    .Select(m => new { Method = m, Score = GetAddMethodScore(m, item) })
+                    .Where(x => x.Score > 0)
+                    .OrderByDescending(x => x.Score)
+                    .Select(x => x.Method);
+                foreach (var method in methods)
                 {
                     if (TryInvokeAddMethod(target, method, item, frame, layer, length, group, sameGroupOnly, layerRange, out var error))
                         return new AddAttempt(true, null, new { target = target.GetType().FullName, method = DescribeMethod(method) });
@@ -1629,6 +1801,18 @@ namespace YMM4McpPlugin
             }
 
             return new AddAttempt(false, "グループ制御アイテムを追加できるメソッドが見つかりません", new { errors = errors.Take(20).ToArray() });
+        }
+
+        private static int GetAddMethodScore(MethodInfo method, object item)
+        {
+            var ps = method.GetParameters();
+            if (ps.Any(p => p.ParameterType.IsAssignableFrom(item.GetType()))) return 100;
+            if (ps.Any(p => p.ParameterType.IsArray && (p.ParameterType.GetElementType()?.IsAssignableFrom(item.GetType()) == true))) return 95;
+            if (ps.Any(p => p.ParameterType != typeof(string)
+                && typeof(System.Collections.IEnumerable).IsAssignableFrom(p.ParameterType)
+                && (p.ParameterType.GetGenericArguments().FirstOrDefault()?.IsAssignableFrom(item.GetType()) == true
+                    || item.GetType().GetInterfaces().Any(i => p.ParameterType.GetGenericArguments().FirstOrDefault()?.IsAssignableFrom(i) == true)))) return 90;
+            return 0;
         }
 
         private static bool TryInvokeAddMethod(object target, MethodInfo method, object item, int frame, int layer, int length, int group, bool sameGroupOnly, int layerRange, out string? error)
@@ -1680,14 +1864,19 @@ namespace YMM4McpPlugin
             var props = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
                 .Where(p => p.GetIndexParameters().Length == 0)
                 .ToArray();
+            string? firstError = null;
+            string? firstFailedProperty = null;
             foreach (var name in names)
             {
                 var p = props.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
                 if (p == null) continue;
                 if (TrySetPropertyValue(obj, p, value, out var error)) return new PropSetResult(true, p.Name, null);
-                return new PropSetResult(false, p.Name, error);
+                firstFailedProperty ??= p.Name;
+                firstError ??= error;
             }
-            return new PropSetResult(false, null, "プロパティが見つかりません");
+            return firstFailedProperty != null
+                ? new PropSetResult(false, firstFailedProperty, firstError)
+                : new PropSetResult(false, null, "プロパティが見つかりません");
         }
 
         private static bool TrySetPropertyValue(object obj, PropertyInfo prop, object value, out string? error)
@@ -1748,6 +1937,12 @@ namespace YMM4McpPlugin
             return null;
         }
 
+        private static bool IsSimpleType(Type type)
+        {
+            var t = Nullable.GetUnderlyingType(type) ?? type;
+            return t.IsPrimitive || t.IsEnum || t == typeof(string) || t == typeof(decimal) || t == typeof(DateTime) || t == typeof(TimeSpan) || t == typeof(Guid);
+        }
+
         private static int GetIntProp(object obj, string name)
         {
             try { return Convert.ToInt32(GetAnyProp(obj, new[] { name }) ?? -1); }
@@ -1783,6 +1978,78 @@ namespace YMM4McpPlugin
 
                 return (object)results;
             });
+        }
+
+        private object DebugItem(HttpListenerRequest req)
+        {
+            int frame = int.TryParse(req.QueryString["frame"], out var f) ? f : -1;
+            int layer = int.TryParse(req.QueryString["layer"], out var l) ? l : -1;
+            string typePattern = req.QueryString["type"] ?? "";
+
+            return Application.Current.Dispatcher.Invoke(() =>
+            {
+                var vm = GetMainViewModel(); if (vm == null) return (object)new { error = "VM失敗" };
+                var tvm = GetPropObj(vm, "ActiveTimelineViewModel"); if (tvm == null) return (object)new { error = "TVM失敗" };
+                var rawItems = GetPropEnum(tvm, "Items"); if (rawItems == null) return (object)new { error = "Items失敗" };
+
+                object? target = null;
+                foreach (var iv in rawItems)
+                {
+                    var item = GetPropObj(iv, "Item") ?? iv;
+                    if (frame >= 0 && GetIntProp(item, "Frame") != frame) continue;
+                    if (layer >= 0 && GetIntProp(item, "Layer") != layer) continue;
+                    if (typePattern.Length > 0 && !item.GetType().Name.Contains(typePattern, StringComparison.OrdinalIgnoreCase)) continue;
+                    target = item;
+                    break;
+                }
+                if (target == null) return (object)new { error = "対象アイテムなし", frame, layer, typePattern };
+
+                return (object)new
+                {
+                    type = target.GetType().FullName,
+                    properties = DescribeObjectMembers(target, 1),
+                };
+            });
+        }
+
+        private static object[] DescribeObjectMembers(object obj, int nestedDepth)
+        {
+            var members = new List<object>();
+            var type = obj.GetType();
+            while (type != null && type != typeof(object))
+            {
+                foreach (var p in type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly))
+                {
+                    if (p.GetIndexParameters().Length > 0) continue;
+                    object? val = null;
+                    string? err = null;
+                    try { val = p.GetValue(obj); } catch (Exception ex) { err = ex.InnerException?.Message ?? ex.Message; }
+                    members.Add(new
+                    {
+                        name = p.Name,
+                        type = p.PropertyType.FullName,
+                        p.CanWrite,
+                        value = DescribeValue(val),
+                        error = err,
+                        nested = nestedDepth > 0 && val != null && !IsSimpleType(val.GetType()) ? DescribeObjectMembers(val, nestedDepth - 1) : null
+                    });
+                }
+                type = type.BaseType;
+            }
+            return members.ToArray();
+        }
+
+        private static string? DescribeValue(object? val)
+        {
+            if (val == null) return null;
+            try
+            {
+                var valueProp = val.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (valueProp != null && valueProp.GetIndexParameters().Length == 0)
+                    return $"{val} (Value: {valueProp.GetValue(val) ?? "null"})";
+                return val.ToString();
+            }
+            catch { return val.ToString(); }
         }
 
         private object SearchProps(HttpListenerRequest req)

--- a/YMM4McpPlugin/McpHttpServer.cs
+++ b/YMM4McpPlugin/McpHttpServer.cs
@@ -1604,7 +1604,7 @@ namespace YMM4McpPlugin
         {
             foreach (var name in names)
             {
-                var p = obj.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                var p = FindProperty(obj.GetType(), name);
                 if (p == null || p.GetIndexParameters().Length > 0) continue;
                 try
                 {
@@ -1614,7 +1614,7 @@ namespace YMM4McpPlugin
                         bool any = false;
                         if (from.HasValue) any |= TrySetNamedValue(target, new[] { "From", "Start", "StartValue", "Begin", "BeginValue" }, from.Value);
                         if (to.HasValue) any |= TrySetNamedValue(target, new[] { "To", "End", "EndValue", "Value" }, to.Value);
-                        if (any) return new { success = true, motion = label, property = p.Name, from, to, mode = "nested" };
+                        if (any) return new { success = true, motion = label, property = p.Name, from, to, mode = "nested", animationType = TryEnableAnimation(target) };
                     }
                     var value = to ?? from;
                     if (value.HasValue && p.CanWrite)
@@ -1648,7 +1648,7 @@ namespace YMM4McpPlugin
             property = null;
             foreach (var name in names)
             {
-                var p = obj.GetType().GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                var p = FindProperty(obj.GetType(), name);
                 if (p == null || p.GetIndexParameters().Length > 0) continue;
                 try
                 {
@@ -1661,6 +1661,45 @@ namespace YMM4McpPlugin
                 catch { }
             }
             return false;
+        }
+
+        private static object TryEnableAnimation(object animation)
+        {
+            var p = FindProperty(animation.GetType(), "AnimationType");
+            if (p == null || !p.CanWrite)
+                return new { success = false, error = "AnimationType property not found" };
+            var t = Nullable.GetUnderlyingType(p.PropertyType) ?? p.PropertyType;
+            if (!t.IsEnum)
+                return new { success = false, error = "AnimationType is not enum" };
+
+            var values = Enum.GetValues(t).Cast<object>().ToArray();
+            object? selected = values.FirstOrDefault(v =>
+            {
+                var s = v.ToString() ?? "";
+                return s.Contains("直線") || s.Contains("Linear", StringComparison.OrdinalIgnoreCase) || s.Contains("補間");
+            }) ?? values.FirstOrDefault(v => Convert.ToInt32(v) != 0);
+            if (selected == null)
+                return new { success = false, error = "AnimationType value not found" };
+
+            try
+            {
+                p.SetValue(animation, selected);
+                return new { success = true, value = selected.ToString() };
+            }
+            catch (Exception ex)
+            {
+                return new { success = false, error = ex.InnerException?.Message ?? ex.Message };
+            }
+        }
+
+        private static PropertyInfo? FindProperty(Type type, string name)
+        {
+            for (var t = type; t != null && t != typeof(object); t = t.BaseType)
+            {
+                var p = t.GetProperty(name, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.DeclaredOnly);
+                if (p != null) return p;
+            }
+            return null;
         }
 
         private static object GetGroupDebugPayload(object? vm, object? tvm, object? mainModel, object? timelineObj)
@@ -1884,6 +1923,11 @@ namespace YMM4McpPlugin
             error = null;
             try
             {
+                if (prop.CanWrite && prop.GetMethod == null)
+                {
+                    prop.SetValue(obj, ConvertTo(value, prop.PropertyType));
+                    return true;
+                }
                 var cur = prop.GetValue(obj);
                 var valueProp = cur?.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
                 if (valueProp != null && valueProp.CanWrite)

--- a/YMM4McpPlugin/McpHttpServer.cs
+++ b/YMM4McpPlugin/McpHttpServer.cs
@@ -105,8 +105,10 @@ namespace YMM4McpPlugin
                     ("GET", "/api/debug/type") => GetTypeInfo(req),
                     ("GET", "/api/debug/timelinemethods") => DebugTimelineMethods(),
                     ("GET", "/api/debug/voicetypes") => DebugVoiceTypes(),
+                    ("GET", "/api/debug/group") => DebugGroup(),
                     ("POST", "/api/items/text") => await AddTextItem(req),
                     ("POST", "/api/items/voice") => await AddVoiceItem(req),
+                    ("POST", "/api/items/group-control") => await AddGroupControlItem(req),
                     ("POST", "/api/items/reorder") => await ReorderItems(req),
                     ("POST", "/api/items/arrange") => await ArrangeItems(req),
                     ("POST", "/api/items/move") => await MoveItem(req),
@@ -116,6 +118,7 @@ namespace YMM4McpPlugin
                     ("POST", "/api/items/effect/video") => await AddVideoEffect(req),
                     ("POST", "/api/items/effect") => await AddEffectToItem(req),
                     ("POST", "/api/items/prop") => await SetItemProp(req),
+                    ("POST", "/api/items/group/add") => await SetItemGroup(req),
                     ("GET", "/api/effects/list") => ListEffects(),
                     ("POST", "/api/items/delete") => await DeleteItems(req),
                     ("GET", "/api/debug/tachie") => DebugTachie(),
@@ -445,6 +448,117 @@ namespace YMM4McpPlugin
                 if (p == null) return (object)new { success = false, error = $"プロパティ'{pName}'なし" };
                 try { p.SetValue(targetItem, Convert.ChangeType(pVal, p.PropertyType)); return (object)new { success = true, prop = pName, value = pVal }; }
                 catch (Exception ex) { return (object)new { success = false, error = ex.Message }; }
+            });
+        }
+
+        private async Task<object> AddGroupControlItem(HttpListenerRequest req)
+        {
+            var b = await ReadBody(req);
+            int frame = GetInt(b, "frame", 0);
+            int layer = GetInt(b, "layer", 0);
+            int length = GetInt(b, "length", 300);
+            int group = GetInt(b, "group", 0);
+            bool sameGroupOnly = GetBool(b, "sameGroupOnly", true);
+            int layerRange = GetInt(b, "layerRange", 0);
+
+            return Application.Current.Dispatcher.Invoke(() =>
+            {
+                var vm = GetMainViewModel(); if (vm == null) return (object)new { success = false, error = "VM失敗" };
+                var tvm = GetPropObj(vm, "ActiveTimelineViewModel"); if (tvm == null) return (object)new { success = false, error = "TVM失敗" };
+                var mainModel = GetMainModel(vm);
+                var timelineObj = GetTimelineObject(vm, tvm);
+                var candidates = GetGroupDebugPayload(vm, tvm, mainModel, timelineObj);
+
+                var type = FindGroupControlType();
+                if (type == null)
+                    return (object)new { success = false, error = "グループ制御アイテム型が見つかりません", candidates };
+
+                object? item = null;
+                try
+                {
+                    item = CreateBestEffort(type, frame, layer, length, group, sameGroupOnly, layerRange);
+                    if (item == null) return (object)new { success = false, error = "グループ制御アイテムを生成できません", type = type.FullName, constructors = DescribeConstructors(type), candidates };
+
+                    var propResults = new List<object>
+                    {
+                        TrySetAnyProp(item, new[] { "Frame" }, frame),
+                        TrySetAnyProp(item, new[] { "Layer" }, layer),
+                        TrySetAnyProp(item, new[] { "Length", "Duration" }, length),
+                        TrySetAnyProp(item, GroupPropNames, group),
+                        TrySetAnyProp(item, new[] { "SameGroupOnly", "IsSameGroupOnly", "TargetSameGroupOnly", "同じグループのみ" }, sameGroupOnly),
+                        TrySetAnyProp(item, new[] { "LayerRange", "Range", "TargetLayerRange", "対象レイヤー数", "レイヤー範囲" }, layerRange)
+                    };
+
+                    var addResult = TryAddTimelineItem(vm, tvm, mainModel, timelineObj, item, frame, layer, length, group, sameGroupOnly, layerRange);
+                    if (!addResult.Success)
+                        return (object)new { success = false, error = addResult.Error, type = type.FullName, properties = propResults, add = addResult.Detail, candidates };
+
+                    return (object)new { success = true, type = type.FullName, frame, layer, length, group, sameGroupOnly, layerRange, add = addResult.Detail, properties = propResults };
+                }
+                catch (Exception ex)
+                {
+                    return (object)new { success = false, error = ex.InnerException?.Message ?? ex.Message, type = type.FullName, candidates };
+                }
+            });
+        }
+
+        private async Task<object> SetItemGroup(HttpListenerRequest req)
+        {
+            var b = await ReadBody(req);
+            int group = GetInt(b, "group", 0);
+            var targets = new List<(int frame, int layer)>();
+            if (b.TryGetValue("targets", out var te) && te.ValueKind == JsonValueKind.Array)
+            {
+                foreach (var t in te.EnumerateArray())
+                {
+                    if (t.ValueKind != JsonValueKind.Object) continue;
+                    int frame = t.TryGetProperty("frame", out var fe) && fe.ValueKind == JsonValueKind.Number ? fe.GetInt32() : -1;
+                    int layer = t.TryGetProperty("layer", out var le) && le.ValueKind == JsonValueKind.Number ? le.GetInt32() : -1;
+                    if (frame >= 0 && layer >= 0) targets.Add((frame, layer));
+                }
+            }
+
+            return Application.Current.Dispatcher.Invoke(() =>
+            {
+                var vm = GetMainViewModel(); if (vm == null) return (object)new { success = false, error = "VM失敗" };
+                var tvm = GetPropObj(vm, "ActiveTimelineViewModel"); if (tvm == null) return (object)new { success = false, error = "TVM失敗" };
+                var rawItems = GetPropEnum(tvm, "Items"); if (rawItems == null) return (object)new { success = false, error = "Items失敗" };
+                if (targets.Count == 0) return (object)new { success = false, error = "targetsが空です" };
+
+                var items = rawItems.Cast<object>()
+                    .Select(iv => new { View = iv, Item = GetPropObj(iv, "Item") ?? iv })
+                    .ToList();
+                var results = new List<object>();
+                int succeeded = 0;
+
+                foreach (var target in targets)
+                {
+                    var found = items.FirstOrDefault(x => GetIntProp(x.Item, "Frame") == target.frame && GetIntProp(x.Item, "Layer") == target.layer);
+                    if (found == null)
+                    {
+                        results.Add(new { target.frame, target.layer, success = false, error = "アイテム未発見" });
+                        continue;
+                    }
+
+                    var before = GetAnyProp(found.Item, GroupPropNames);
+                    var set = TrySetAnyProp(found.Item, GroupPropNames, group);
+                    var after = GetAnyProp(found.Item, GroupPropNames);
+                    if (set.Success) succeeded++;
+                    results.Add(new
+                    {
+                        target.frame,
+                        target.layer,
+                        itemType = found.Item.GetType().FullName,
+                        success = set.Success,
+                        property = set.Property,
+                        before,
+                        after,
+                        error = set.Error,
+                        groupProperties = set.Success ? null : DescribeMatchingProperties(found.Item.GetType(), "Group")
+                    });
+                }
+
+                return (object)new { success = succeeded == targets.Count, targetCount = targets.Count, successCount = succeeded, failureCount = targets.Count - succeeded, results };
             });
         }
 
@@ -1077,6 +1191,19 @@ namespace YMM4McpPlugin
             });
         }
 
+        private object DebugGroup()
+        {
+            return Application.Current.Dispatcher.Invoke(() =>
+            {
+                var vm = GetMainViewModel();
+                if (vm == null) return (object)new { error = "MainViewModel取得失敗" };
+                var tvm = GetPropObj(vm, "ActiveTimelineViewModel");
+                var mainModel = GetMainModel(vm);
+                var timelineObj = tvm != null ? GetTimelineObject(vm, tvm) : null;
+                return GetGroupDebugPayload(vm, tvm, mainModel, timelineObj);
+            });
+        }
+
         private object DebugItems()
         {
             return Application.Current.Dispatcher.Invoke(() =>
@@ -1324,6 +1451,11 @@ namespace YMM4McpPlugin
 
         // ── ヘルパー ──────────────────────────────────────────
 
+        private static readonly string[] GroupPropNames = new[]
+        {
+            "Group", "GroupId", "GroupID", "GroupIndex", "GroupNo", "GroupNumber", "GroupName", "グループ"
+        };
+
         private static object? GetMainViewModel()
         {
             return Application.Current.Windows.OfType<Window>()
@@ -1334,6 +1466,302 @@ namespace YMM4McpPlugin
         private static object? GetPropObj(object o, string n) { try { var t = o.GetType(); return (t.GetProperty(n) ?? t.GetProperty(n, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))?.GetValue(o) ?? (t.GetField(n) ?? t.GetField(n, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))?.GetValue(o); } catch { return null; } }
         private static string GetPropStr(object o, string n) { try { return (o.GetType().GetProperty(n) ?? o.GetType().GetProperty(n, BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))?.GetValue(o) as string ?? ""; } catch { return ""; } }
         private static System.Collections.IEnumerable? GetPropEnum(object o, string n) { try { return o.GetType().GetProperty(n)?.GetValue(o) as System.Collections.IEnumerable; } catch { return null; } }
+
+        private static object? GetTimelineObject(object vm, object tvm)
+        {
+            return GetPropObj(tvm, "Timeline")
+                ?? GetPropObj(vm, "Timeline")
+                ?? tvm.GetType().GetField("timeline", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(tvm)
+                ?? tvm.GetType().GetField("_timeline", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(tvm);
+        }
+
+        private static IEnumerable<Type> GetLoadedTypes()
+        {
+            return AppDomain.CurrentDomain.GetAssemblies()
+                .SelectMany(a => { try { return a.GetTypes(); } catch { return System.Array.Empty<Type>(); } });
+        }
+
+        private static bool IsGroupRelated(string? text)
+        {
+            if (string.IsNullOrEmpty(text)) return false;
+            return text.Contains("Group", StringComparison.OrdinalIgnoreCase) || text.Contains("グループ") || text.Contains("群");
+        }
+
+        private static Type? FindGroupControlType()
+        {
+            return GetLoadedTypes()
+                .Where(t => !t.IsAbstract && !t.IsInterface && !t.IsEnum && IsGroupControlRelated(t.Name, t.FullName))
+                .OrderByDescending(t => t.Name.Contains("Item", StringComparison.OrdinalIgnoreCase))
+                .FirstOrDefault();
+        }
+
+        private static bool IsGroupControlRelated(string name, string? fullName)
+        {
+            return name.Contains("GroupControl", StringComparison.OrdinalIgnoreCase)
+                || (fullName?.Contains("GroupControl", StringComparison.OrdinalIgnoreCase) == true)
+                || name.Contains("グループ制御")
+                || (fullName?.Contains("グループ制御") == true);
+        }
+
+        private static object GetGroupDebugPayload(object? vm, object? tvm, object? mainModel, object? timelineObj)
+        {
+            var groupTypes = GetLoadedTypes()
+                .Where(t => IsGroupRelated(t.Name) || IsGroupRelated(t.FullName))
+                .Select(t => new
+                {
+                    t.FullName,
+                    t.Name,
+                    t.IsAbstract,
+                    constructors = DescribeConstructors(t),
+                    properties = t.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                        .Where(p => IsGroupRelated(p.Name) || p.Name is "Frame" or "Layer" or "Length")
+                        .Select(p => new { p.Name, type = p.PropertyType.FullName, p.CanWrite })
+                        .ToArray(),
+                    methods = t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance | BindingFlags.Static)
+                        .Where(m => IsGroupRelated(m.Name))
+                        .Select(DescribeMethod)
+                        .Take(30)
+                        .ToArray()
+                })
+                .Take(80)
+                .ToArray();
+
+            return new
+            {
+                groupTypes,
+                activeTimelineViewModel = DescribeGroupMembers("ActiveTimelineViewModel", tvm),
+                mainModel = DescribeGroupMembers("MainModel", mainModel),
+                timeline = DescribeGroupMembers("timeline", timelineObj),
+                mainViewModel = DescribeGroupMembers("MainViewModel", vm),
+            };
+        }
+
+        private static object DescribeGroupMembers(string name, object? obj)
+        {
+            if (obj == null) return new { name, found = false };
+            var type = obj.GetType();
+            return new
+            {
+                name,
+                found = true,
+                type = type.FullName,
+                methods = type.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                    .Where(m => IsGroupRelated(m.Name) || m.Name.Contains("Add") || m.Name.Contains("Item"))
+                    .Select(DescribeMethod)
+                    .Take(80)
+                    .ToArray(),
+                properties = type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                    .Where(p => IsGroupRelated(p.Name) || IsGroupRelated(p.PropertyType.Name))
+                    .Select(p => new { p.Name, type = p.PropertyType.FullName, p.CanWrite })
+                    .Take(80)
+                    .ToArray(),
+                fields = type.GetFields(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                    .Where(f => IsGroupRelated(f.Name) || IsGroupRelated(f.FieldType.Name) || f.Name.Contains("timeline", StringComparison.OrdinalIgnoreCase))
+                    .Select(f => new { f.Name, type = f.FieldType.FullName })
+                    .Take(80)
+                    .ToArray()
+            };
+        }
+
+        private static string[] DescribeConstructors(Type type)
+        {
+            return type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Select(c => "(" + string.Join(", ", c.GetParameters().Select(p => $"{p.ParameterType.Name} {p.Name}")) + ")")
+                .ToArray();
+        }
+
+        private static string DescribeMethod(MethodInfo m)
+        {
+            return $"{m.Name}({string.Join(", ", m.GetParameters().Select(p => p.ParameterType.Name + " " + p.Name))})";
+        }
+
+        private static object? CreateBestEffort(Type type, int frame, int layer, int length, int group, bool sameGroupOnly, int layerRange)
+        {
+            var constructors = type.GetConstructors(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .OrderBy(c => c.GetParameters().Length == 0 ? 0 : 1)
+                .ThenBy(c => c.GetParameters().Length);
+            foreach (var ctor in constructors)
+            {
+                try
+                {
+                    var args = ctor.GetParameters().Select(p => GuessValueForParameter(p, frame, layer, length, group, sameGroupOnly, layerRange)).ToArray();
+                    return ctor.Invoke(args);
+                }
+                catch { }
+            }
+            return null;
+        }
+
+        private static object? GuessValueForParameter(ParameterInfo p, int frame, int layer, int length, int group, bool sameGroupOnly, int layerRange)
+        {
+            var n = p.Name ?? "";
+            var t = Nullable.GetUnderlyingType(p.ParameterType) ?? p.ParameterType;
+            if (t == typeof(int))
+            {
+                if (n.Contains("frame", StringComparison.OrdinalIgnoreCase)) return frame;
+                if (n.Contains("layer", StringComparison.OrdinalIgnoreCase) && n.Contains("range", StringComparison.OrdinalIgnoreCase)) return layerRange;
+                if (n.Contains("layer", StringComparison.OrdinalIgnoreCase)) return layer;
+                if (n.Contains("length", StringComparison.OrdinalIgnoreCase) || n.Contains("duration", StringComparison.OrdinalIgnoreCase)) return length;
+                if (n.Contains("group", StringComparison.OrdinalIgnoreCase)) return group;
+                return 0;
+            }
+            if (t == typeof(bool)) return n.Contains("same", StringComparison.OrdinalIgnoreCase) || sameGroupOnly;
+            if (t == typeof(string)) return "";
+            if (t.IsEnum) return Enum.GetValues(t).GetValue(0);
+            return p.HasDefaultValue ? p.DefaultValue : null;
+        }
+
+        private readonly record struct AddAttempt(bool Success, string? Error, object? Detail);
+
+        private static AddAttempt TryAddTimelineItem(object vm, object tvm, object? mainModel, object? timelineObj, object item, int frame, int layer, int length, int group, bool sameGroupOnly, int layerRange)
+        {
+            var targets = new[] { mainModel, timelineObj, tvm, vm }.Where(x => x != null).Cast<object>().ToArray();
+            var errors = new List<string>();
+
+            foreach (var target in targets)
+            {
+                foreach (var method in target.GetType().GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance).Where(m => m.Name.Contains("Add") && (m.Name.Contains("Group") || m.Name.Contains("Item"))))
+                {
+                    if (TryInvokeAddMethod(target, method, item, frame, layer, length, group, sameGroupOnly, layerRange, out var error))
+                        return new AddAttempt(true, null, new { target = target.GetType().FullName, method = DescribeMethod(method) });
+                    if (!string.IsNullOrEmpty(error)) errors.Add($"{target.GetType().Name}.{method.Name}: {error}");
+                }
+            }
+
+            return new AddAttempt(false, "グループ制御アイテムを追加できるメソッドが見つかりません", new { errors = errors.Take(20).ToArray() });
+        }
+
+        private static bool TryInvokeAddMethod(object target, MethodInfo method, object item, int frame, int layer, int length, int group, bool sameGroupOnly, int layerRange, out string? error)
+        {
+            error = null;
+            try
+            {
+                var ps = method.GetParameters();
+                object?[] args;
+                if (ps.Length == 1 && ps[0].ParameterType.IsAssignableFrom(item.GetType()))
+                {
+                    args = new[] { item };
+                }
+                else if (ps.Length == 1 && typeof(System.Collections.IEnumerable).IsAssignableFrom(ps[0].ParameterType) && ps[0].ParameterType != typeof(string))
+                {
+                    var elemType = ps[0].ParameterType.IsArray
+                        ? ps[0].ParameterType.GetElementType()
+                        : item.GetType().GetInterfaces().FirstOrDefault(i => i.Name == "IItem")
+                          ?? ps[0].ParameterType.GetGenericArguments().FirstOrDefault()
+                          ?? item.GetType();
+                    var arr = Array.CreateInstance(elemType ?? item.GetType(), 1);
+                    arr.SetValue(item, 0);
+                    args = new object?[] { arr };
+                }
+                else
+                {
+                    args = ps.Select(p => GuessValueForParameter(p, frame, layer, length, group, sameGroupOnly, layerRange)).ToArray();
+                    for (int i = 0; i < ps.Length; i++)
+                    {
+                        if (args[i] == null && ps[i].ParameterType.IsAssignableFrom(item.GetType())) args[i] = item;
+                    }
+                }
+
+                var result = method.Invoke(target, args);
+                if (result is Task t) t.GetAwaiter().GetResult();
+                return true;
+            }
+            catch (Exception ex)
+            {
+                error = ex.InnerException?.Message ?? ex.Message;
+                return false;
+            }
+        }
+
+        private readonly record struct PropSetResult(bool Success, string? Property, string? Error);
+
+        private static PropSetResult TrySetAnyProp(object obj, IEnumerable<string> names, object value)
+        {
+            var props = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(p => p.GetIndexParameters().Length == 0)
+                .ToArray();
+            foreach (var name in names)
+            {
+                var p = props.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+                if (p == null) continue;
+                if (TrySetPropertyValue(obj, p, value, out var error)) return new PropSetResult(true, p.Name, null);
+                return new PropSetResult(false, p.Name, error);
+            }
+            return new PropSetResult(false, null, "プロパティが見つかりません");
+        }
+
+        private static bool TrySetPropertyValue(object obj, PropertyInfo prop, object value, out string? error)
+        {
+            error = null;
+            try
+            {
+                var cur = prop.GetValue(obj);
+                var valueProp = cur?.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                if (valueProp != null && valueProp.CanWrite)
+                {
+                    valueProp.SetValue(cur, ConvertTo(value, valueProp.PropertyType));
+                    return true;
+                }
+                if (prop.CanWrite)
+                {
+                    prop.SetValue(obj, ConvertTo(value, prop.PropertyType));
+                    return true;
+                }
+                error = "書き込み不可";
+                return false;
+            }
+            catch (Exception ex)
+            {
+                error = ex.InnerException?.Message ?? ex.Message;
+                return false;
+            }
+        }
+
+        private static object? ConvertTo(object value, Type type)
+        {
+            var t = Nullable.GetUnderlyingType(type) ?? type;
+            if (t.IsEnum)
+            {
+                if (value is string s) return Enum.Parse(t, s, true);
+                return Enum.ToObject(t, value);
+            }
+            return Convert.ChangeType(value, t);
+        }
+
+        private static object? GetAnyProp(object obj, IEnumerable<string> names)
+        {
+            var props = obj.GetType().GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(p => p.GetIndexParameters().Length == 0)
+                .ToArray();
+            foreach (var name in names)
+            {
+                var p = props.FirstOrDefault(x => x.Name.Equals(name, StringComparison.OrdinalIgnoreCase));
+                if (p == null) continue;
+                try
+                {
+                    var val = p.GetValue(obj);
+                    var valueProp = val?.GetType().GetProperty("Value", BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance);
+                    return valueProp != null ? valueProp.GetValue(val) : val;
+                }
+                catch { }
+            }
+            return null;
+        }
+
+        private static int GetIntProp(object obj, string name)
+        {
+            try { return Convert.ToInt32(GetAnyProp(obj, new[] { name }) ?? -1); }
+            catch { return -1; }
+        }
+
+        private static object[] DescribeMatchingProperties(Type type, string pattern)
+        {
+            return type.GetProperties(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance)
+                .Where(p => p.Name.Contains(pattern, StringComparison.OrdinalIgnoreCase) || p.Name.Contains("グループ"))
+                .Select(p => new { p.Name, type = p.PropertyType.FullName, p.CanWrite })
+                .Cast<object>()
+                .ToArray();
+        }
 
         private object GetProps(HttpListenerRequest req)
         {
@@ -1638,6 +2066,7 @@ namespace YMM4McpPlugin
 
         private static string GetStr(Dictionary<string, JsonElement> d, string k, string def) => d.TryGetValue(k, out var v) && v.ValueKind == JsonValueKind.String ? v.GetString() ?? def : def;
         private static int GetInt(Dictionary<string, JsonElement> d, string k, int def) => d.TryGetValue(k, out var v) && v.ValueKind == JsonValueKind.Number ? v.GetInt32() : def;
+        private static bool GetBool(Dictionary<string, JsonElement> d, string k, bool def) => d.TryGetValue(k, out var v) ? v.ValueKind switch { JsonValueKind.True => true, JsonValueKind.False => false, _ => def } : def;
         private void Log(string msg) => LogMessage?.Invoke($"[{DateTime.Now:HH:mm:ss}] {msg}");
 
         // ================================================================

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -74,7 +74,7 @@ TOOLS = [
                 },
                 "sub_action": {
                     "type": "string",
-                    "description": "情報取得(status,project,items,effects_list)、操作(play,stop,save)、アイテム追加(text,voice,tachie,face)、編集(face_param,property,effect,delete,duration)のいずれか"
+                    "description": "情報取得(status,project,items,effects_list,group_debug)、操作(play,stop,save)、アイテム追加(text,voice,tachie,face,group_control)、編集(face_param,property,effect,delete,duration,group)のいずれか"
                 },
                 "text": {"type": "string", "description": "表示または発話テキスト"},
                 "character": {"type": "string", "description": "キャラクター名"},
@@ -87,6 +87,20 @@ TOOLS = [
                 "params": {"type": "object"},
                 "frames": {"type": "integer"},
                 "layers": {"type": "array", "items": {"type": "integer"}},
+                "group": {"type": "integer"},
+                "sameGroupOnly": {"type": "boolean"},
+                "layerRange": {"type": "integer"},
+                "targets": {
+                    "type": "array",
+                    "items": {
+                        "type": "object",
+                        "properties": {
+                            "frame": {"type": "integer"},
+                            "layer": {"type": "integer"}
+                        },
+                        "required": ["frame", "layer"]
+                    }
+                },
                 "lines": {
                     "type": "array",
                     "items": {"type": "object", "properties": {"character": {"type": "string"}, "text": {"type": "string"}, "layer": {"type": "integer"}}}
@@ -162,6 +176,7 @@ async def dispatch(args: dict) -> Any:
                 case "project": return await ymm4_get("/project")
                 case "items": return await ymm4_get("/items")
                 case "effects_list": return await ymm4_get("/effects/list")
+                case "group_debug": return await ymm4_get("/debug/group")
                 case _: raise ValueError(f"Unknown sub_action for get_info: {sub_action}")
 
         case "control":
@@ -178,12 +193,16 @@ async def dispatch(args: dict) -> Any:
             if "frame" in args: payload["frame"] = args["frame"]
             if "layer" in args: payload["layer"] = args["layer"]
             if "length" in args: payload["length"] = args["length"]
+            if "group" in args: payload["group"] = args["group"]
+            if "sameGroupOnly" in args: payload["sameGroupOnly"] = args["sameGroupOnly"]
+            if "layerRange" in args: payload["layerRange"] = args["layerRange"]
             
             match sub_action:
                 case "text": return await ymm4_post("/items/text", payload)
                 case "voice": return await ymm4_post("/items/voice", payload)
                 case "tachie": return await ymm4_post("/items/tachie", payload)
                 case "face": return await ymm4_post("/items/face", payload)
+                case "group_control": return await ymm4_post("/items/group-control", payload)
                 case _: raise ValueError(f"Unknown sub_action for add_item: {sub_action}")
 
         case "edit_item":
@@ -214,6 +233,11 @@ async def dispatch(args: dict) -> Any:
                     return await ymm4_post("/items/delete", payload)
                 case "duration":
                     return await ymm4_post("/timeline/duration", {"frames": args.get("frames", 0)})
+                case "group":
+                    return await ymm4_post("/items/group/add", {
+                        "targets": args.get("targets", []),
+                        "group": args.get("group", 0)
+                    })
                 case _: raise ValueError(f"Unknown sub_action for edit_item: {sub_action}")
 
         case "add_script":

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -90,6 +90,13 @@ TOOLS = [
                 "group": {"type": "integer"},
                 "sameGroupOnly": {"type": "boolean"},
                 "layerRange": {"type": "integer"},
+                "x": {"type": "array", "items": {"type": "number"}, "description": "group_control beta: [from, to] X motion"},
+                "y": {"type": "array", "items": {"type": "number"}, "description": "group_control beta: [from, to] Y motion"},
+                "zoom": {"type": "array", "items": {"type": "number"}, "description": "group_control beta: [from, to] zoom motion"},
+                "scale": {"type": "array", "items": {"type": "number"}, "description": "group_control beta: [from, to] scale motion"},
+                "rotation": {"type": "array", "items": {"type": "number"}, "description": "group_control beta: [from, to] rotation motion"},
+                "opacity": {"type": "array", "items": {"type": "number"}, "description": "group_control beta: [from, to] opacity motion"},
+                "repeat": {"type": "boolean", "description": "group_control beta: repeat/loop flag when YMM4 exposes a compatible property"},
                 "targets": {
                     "type": "array",
                     "items": {
@@ -196,6 +203,8 @@ async def dispatch(args: dict) -> Any:
             if "group" in args: payload["group"] = args["group"]
             if "sameGroupOnly" in args: payload["sameGroupOnly"] = args["sameGroupOnly"]
             if "layerRange" in args: payload["layerRange"] = args["layerRange"]
+            for key in ("x", "y", "zoom", "scale", "rotation", "opacity", "repeat"):
+                if key in args: payload[key] = args[key]
             
             match sub_action:
                 case "text": return await ymm4_post("/items/text", payload)


### PR DESCRIPTION
## Summary

- Add HTTP APIs for YMM4 group control items and item group assignment.
- Add beta motion field support for group-control X/Y/Zoom/Rotation/Opacity and MCP forwarding.
- Document the new HTTP and MCP APIs, including beta/internal API compatibility notes.

## Verification

- dotnet build YMM4McpPlugin/YMM4McpPlugin.csproj -c Debug -p:YMM4InstallPath=C:\Git\ymm4MCP\.tmp\YMM4Copy
- Runtime API check against YMM4 MCP server: created GroupItem at frame 600 and 1200 with GroupRange/IsGroupOnly and X/Y/Zoom/Rotation/Opacity set to AnimationType=直線移動

## Notes

- Group-related YMM4 internals are resolved via reflection and should be treated as beta-level compatibility.
- Python py_compile was not run locally because Python/py launcher was unavailable in this environment.
- dotnet build currently reports existing NAudio 2.2.1 / 2.3.0 conflict warnings.