### PR TITLE
feat: Gemini動画解析 — 映像イベントをタイムスタンプ+フレーム番号で検出

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -118,6 +118,8 @@ pip install -r requirements.txt
 | `GET  /api/preview/capture` | 現在フレームをPNG取得 |
 | `POST /api/preview/seek` | 指定フレームへシーク＋PNG取得 |
 | `GET  /api/preview/position` | 現在の再生位置取得 |
+| `POST /api/preview/export-clip` | ★区間を連番PNG＋音声WAVで書き出す（Gemini解析用） |
+| `GET  /api/project/fps` | ★プロジェクトのFPS・解像度を取得（時刻→フレーム変換用） |
 | `POST /api/playback/play` | 再生開始 |
 | `POST /api/playback/stop` | 再生停止 |
 
@@ -259,6 +261,72 @@ action="list_commands"
 > **設計思想**: `SplitItemCommand`/`AlignItemsCommand` 等の正確なコマンド名はYMM4バージョンで
 > 異なる場合があります。`list_commands`/`inspect`で実際の名前を発見してから`command`で実行する
 > ワークフローにより、バージョン差異を吸収できます。
+
+---
+
+### `ymm4_analyze_video`（Gemini動画解析系）★NEW
+
+動画を時系列で精密に解析し、「いつ・何が起きたか」（シーン変化／キャラ登場／効果音／テロップ／
+動き等）を**タイムスタンプ + YMM4フレーム番号付き**で検出します。
+プレビュー画像の単発取得では難しかった「イベント発生フレームの特定」と「音声・映像の同期」を、
+Gemini のネイティブ動画理解で実現します。
+
+#### 仕組み（役割分担）
+```
+[YMM4プレビュー or 元動画]
+   ↓ C#: 区間を連番PNG+音声WAVに書き出す / もしくは動画ファイルをそのまま渡す
+[Gemini API] 映像+音声を時系列解析 → タイムスタンプ付きイベントJSON
+   ↓ Python: time_sec を FPS でフレーム番号に変換
+[Claude] イベントに合わせてセリフ生成・add_scriptで配置
+```
+全フレームをClaudeに投げるのではなく、**重い解析はGeminiに集約**し、Claudeは構造化済みの
+イベントリストを受け取って意味づけ・台本化に専念します。
+
+#### 2つのモード
+| source | 解析対象 | 主なパラメータ |
+|---|---|---|
+| `preview` | YMM4プレビューの指定フレーム区間（配置済み素材） | `start_frame` / `end_frame` / `step_frames` / `record_audio` |
+| `file` | 取り込み前の元動画ファイル(mp4等) | `video_path` / `base_frame` / `fps` |
+
+#### 検出イベントのカスタマイズ
+`event_instruction` で検出したいイベントを自由に指定できます（**未指定なら全イベント検出**）。
+```python
+# 全部検出（デフォルト）
+action source="preview", start_frame=0, end_frame=600
+
+# 効果音とキャラ登場だけに絞る
+event_instruction="効果音が鳴った瞬間と、新しいキャラが画面に出た瞬間だけ検出して"
+
+# 元動画ファイルを解析し、フレーム300以降に対応づける
+source="file", video_path="C:/movie/boss.mp4", base_frame=300
+```
+
+#### 戻り値（例）
+```json
+{
+  "success": true,
+  "summary": "ボス戦の動画。中盤で敵が出現し、終盤に撃破される。",
+  "events": [
+    {
+      "time_sec": 12.3, "end_sec": 14.0,
+      "frame": 369, "end_frame": 420,          // ← FPSから自動変換されたYMM4フレーム
+      "type": "character", "label": "ボス出現",
+      "description": "画面中央に大型の敵が出現", "audio": "重低音のSE",
+      "importance": 5
+    }
+  ],
+  "fps_used": 30, "base_frame": 0
+}
+```
+`frame` がそのまま `add_script` の `start_frame` 等に使えるため、**映像イベントに同期したセリフ配置**が可能です。
+
+#### セットアップ
+1. `pip install google-genai`（`requirements.txt` に追加済み）
+2. [Google AI Studio](https://aistudio.google.com/) でAPIキーを発行
+3. `claude_desktop_config.json` の `env` に `GEMINI_API_KEY` を設定（`claude_desktop_config_example.json` 参照）
+
+> モデルは既定 `gemini-2.5-flash`。高精度が必要なら `model="gemini-2.5-pro"` を指定。
+> APIキー未設定/SDK未導入でもサーバーは起動し、解析ツール呼び出し時に案内メッセージを返します。
 
 ---
 

--- a/YMM4McpPlugin/McpHttpServer.cs
+++ b/YMM4McpPlugin/McpHttpServer.cs
@@ -130,6 +130,8 @@ namespace YMM4McpPlugin
                     ("GET", "/api/preview/position") => GetPlaybackPosition(),
                     ("POST", "/api/preview/record") => await RecordAudio(req),
                     ("POST", "/api/preview/watch") => await WatchScene(req),
+                    ("POST", "/api/preview/export-clip") => await ExportClip(req),
+                    ("GET",  "/api/project/fps") => GetProjectFps(),
                     ("POST", "/api/timeline/duration") => await SetTimelineDuration(req),
                     ("POST", "/api/playback/play") => await PlaybackControl("play"),
                     ("POST", "/api/playback/stop") => await PlaybackControl("stop"),
@@ -2569,6 +2571,205 @@ namespace YMM4McpPlugin
                 };
             }
             catch (Exception ex) { return (object)new { success = false, error = ex.Message }; }
+        }
+
+        /// <summary>プロジェクトのFPS(と解像度)を取得する。タイムスタンプ→フレーム変換の基準として使う。</summary>
+        private object GetProjectFps()
+        {
+            return Application.Current.Dispatcher.Invoke(() =>
+            {
+                var vm = GetMainViewModel();
+                if (vm == null) return (object)new { success = false, error = "MainViewModel取得失敗" };
+
+                // Project / Scene / Video情報からFPS・解像度を探索
+                object? project = GetPropObj(vm, "Project") ?? GetPropObj(vm, "project") ?? GetPropObj(vm, "_project");
+                var tvm = GetPropObj(vm, "ActiveTimelineViewModel");
+
+                int? fps = null, width = null, height = null;
+                foreach (var src in new object?[] { project, tvm,
+                    tvm != null ? GetType_Field(tvm, "scene") : null,
+                    tvm != null ? GetType_Field(tvm, "timeline") : null })
+                {
+                    if (src == null) continue;
+                    foreach (var fpsName in new[] { "FPS", "Fps", "FrameRate", "VideoFPS", "VideoInfo" })
+                    {
+                        var v = GetNestedInt(src, fpsName);
+                        if (v.HasValue && v.Value > 0 && v.Value <= 240) { fps ??= v; }
+                    }
+                    foreach (var wn in new[] { "Width", "VideoWidth", "ScreenWidth" }) { var v = GetNestedInt(src, wn); if (v.HasValue && v > 0) width ??= v; }
+                    foreach (var hn in new[] { "Height", "VideoHeight", "ScreenHeight" }) { var v = GetNestedInt(src, hn); if (v.HasValue && v > 0) height ??= v; }
+                }
+
+                return (object)new { success = true, fps = fps ?? 30, width, height, note = fps == null ? "FPS自動検出失敗のため30を仮定" : null };
+            });
+        }
+
+        private static object? GetType_Field(object o, string name)
+        {
+            try { return o.GetType().GetField(name, BindingFlags.NonPublic | BindingFlags.Instance)?.GetValue(o); }
+            catch { return null; }
+        }
+
+        /// <summary>オブジェクトのプロパティ/フィールド(ReactiveProperty含む)を辿って int を取り出す。VideoInfo等のネストも1段掘る。</summary>
+        private static int? GetNestedInt(object o, string name)
+        {
+            try
+            {
+                var val = GetPropValue(o, name) ?? GetType_Field(o, name);
+                if (val == null) return null;
+                if (val is int i) return i;
+                if (int.TryParse(val.ToString(), out int p)) return p;
+                // ネストオブジェクトなら FPS/Width 等をもう1段
+                foreach (var inner in new[] { "FPS", "Fps", "FrameRate", "Width", "Height", "Value" })
+                {
+                    var iv = GetPropValue(val, inner);
+                    if (iv != null && int.TryParse(iv.ToString(), out int p2)) return p2;
+                }
+            }
+            catch { }
+            return null;
+        }
+
+        /// <summary>
+        /// 【案A：プレビュー解析用】指定区間をフレーム単位でシーク＆キャプチャし、連番PNGをディスクに保存する。
+        /// 同時に区間の音声をWAVで録音して同じフォルダに保存する。
+        /// 戻り値は保存先フォルダと各フレームのメタ情報(frame番号/timeMs/ファイル名)。
+        /// Python側はこのフォルダの画像群＋WAVをGeminiへ渡して解析する。
+        ///
+        /// POST body: {
+        ///   "startFrame": 0, "endFrame": 300,   // 解析するフレーム範囲
+        ///   "stepFrames": 3,                    // 何フレームおきにキャプチャするか(粒度)
+        ///   "outputDir": "C:\\...\\clip",       // 省略時は一時フォルダ
+        ///   "recordAudio": true                 // 区間音声も録音するか
+        /// }
+        /// </summary>
+        private async Task<object> ExportClip(HttpListenerRequest req)
+        {
+            try
+            {
+                var body = await ReadBody(req);
+                int startFrame = GetInt(body, "startFrame", 0);
+                int endFrame = GetInt(body, "endFrame", startFrame + 300);
+                int stepFrames = Math.Max(1, GetInt(body, "stepFrames", 3));
+                bool recordAudio = !(body.TryGetValue("recordAudio", out var ra) && ra.ValueKind == JsonValueKind.False);
+                string outputDir = GetStr(body, "outputDir", "");
+
+                if (endFrame < startFrame) return new { success = false, error = "endFrame は startFrame 以上である必要があります" };
+                // 無制限のフレーム数で固まらないよう上限を設ける
+                int totalShots = (endFrame - startFrame) / stepFrames + 1;
+                if (totalShots > 2000) return new { success = false, error = $"フレーム数が多すぎます({totalShots})。stepFramesを大きくするか範囲を狭めてください" };
+
+                if (string.IsNullOrEmpty(outputDir))
+                    outputDir = System.IO.Path.Combine(System.IO.Path.GetTempPath(), "ymm4_clip_" + DateTime.Now.ToString("yyyyMMdd_HHmmss"));
+                System.IO.Directory.CreateDirectory(outputDir);
+
+                var preview = Application.Current.Dispatcher.Invoke(() => GetPreviewViewModel());
+                if (preview == null) return new { success = false, error = "PreviewViewModel not found" };
+
+                // FPS取得(タイムスタンプ計算用)
+                int fps = 30;
+                try { var f = GetProjectFps(); var fp = f.GetType().GetProperty("fps")?.GetValue(f); if (fp != null) int.TryParse(fp.ToString(), out fps); } catch { }
+                if (fps <= 0) fps = 30;
+
+                // ── 音声録音をバックグラウンドで開始（オプション） ──
+                NAudio.Wave.WasapiLoopbackCapture? capture = null;
+                System.Collections.Concurrent.ConcurrentBag<byte[]>? audioBuffer = null;
+                NAudio.Wave.WaveFormat? waveFormat = null;
+                TaskCompletionSource<bool>? recordTcs = null;
+                string? wavPath = null;
+
+                // ── フレームを順にシーク＆キャプチャ ──
+                var savedFrames = new List<object>();
+                var swTotal = System.Diagnostics.Stopwatch.StartNew();
+
+                if (recordAudio)
+                {
+                    // 区間先頭にシークしてから再生＆録音
+                    await InvokeAsyncMethod(preview, "SeekAsync", startFrame);
+                    await Task.Delay(200);
+                    capture = new NAudio.Wave.WasapiLoopbackCapture();
+                    waveFormat = capture.WaveFormat;
+                    audioBuffer = new System.Collections.Concurrent.ConcurrentBag<byte[]>();
+                    recordTcs = new TaskCompletionSource<bool>();
+                    capture.DataAvailable += (s, e) =>
+                    {
+                        if (e.BytesRecorded > 0)
+                        {
+                            var chunk = new byte[e.BytesRecorded];
+                            Buffer.BlockCopy(e.Buffer, 0, chunk, 0, e.BytesRecorded);
+                            audioBuffer.Add(chunk);
+                        }
+                    };
+                    capture.RecordingStopped += (s, e) => recordTcs.TrySetResult(true);
+                    capture.StartRecording();
+                    await InvokeAsyncMethod(preview, "TogglePlayAsync");
+                }
+
+                int index = 0;
+                for (int frame = startFrame; frame <= endFrame; frame += stepFrames)
+                {
+                    // 再生中(録音中)はSeekせず再生位置のキャプチャを行うとズレるため、
+                    // 録音時は実時間ベースで待機しながらキャプチャ、非録音時はSeekしてキャプチャ
+                    if (recordAudio)
+                    {
+                        int targetMs = (int)((frame - startFrame) * 1000.0 / fps);
+                        int waitMs = targetMs - (int)swTotal.ElapsedMilliseconds;
+                        if (waitMs > 0) await Task.Delay(waitMs);
+                    }
+                    else
+                    {
+                        await InvokeAsyncMethod(preview, "SeekAsync", frame);
+                        await Task.Delay(120); // 描画待ち
+                    }
+
+                    string? b64 = null; int w = 0, h = 0;
+                    Application.Current.Dispatcher.Invoke(() => { var r = CaptureCurrentFrame(); b64 = r.b64; w = r.w; h = r.h; });
+                    if (b64 == null) continue;
+
+                    string fileName = $"frame_{index:D5}_f{frame}.png";
+                    string filePath = System.IO.Path.Combine(outputDir, fileName);
+                    try { System.IO.File.WriteAllBytes(filePath, Convert.FromBase64String(b64)); }
+                    catch (Exception ex) { savedFrames.Add(new { frame, error = ex.Message }); continue; }
+
+                    double timeMs = (frame - startFrame) * 1000.0 / fps;
+                    savedFrames.Add(new { index, frame, timeMs = Math.Round(timeMs, 1), file = fileName, width = w, height = h });
+                    index++;
+                }
+
+                // ── 音声停止＆保存 ──
+                double rms = 0; bool hasAudio = false;
+                if (recordAudio && capture != null && waveFormat != null && audioBuffer != null && recordTcs != null)
+                {
+                    try { await InvokeAsyncMethod(preview, "StopAsync"); } catch { }
+                    capture.StopRecording();
+                    await Task.WhenAny(recordTcs.Task, Task.Delay(2000));
+                    var allBytes = audioBuffer.SelectMany(b => b).ToArray();
+                    wavPath = System.IO.Path.Combine(outputDir, "audio.wav");
+                    using (var fs = new FileStream(wavPath, FileMode.Create))
+                    using (var writer = new NAudio.Wave.WaveFileWriter(fs, waveFormat))
+                        writer.Write(allBytes, 0, allBytes.Length);
+                    rms = CalcRms(allBytes, waveFormat.BitsPerSample);
+                    hasAudio = rms > 0.0005;
+                    capture.Dispose();
+                }
+
+                return new
+                {
+                    success = true,
+                    outputDir,
+                    fps,
+                    startFrame,
+                    endFrame,
+                    stepFrames,
+                    frameCount = index,
+                    durationMs = Math.Round((endFrame - startFrame) * 1000.0 / fps, 1),
+                    audioFile = wavPath,
+                    audioRms = Math.Round(rms, 4),
+                    hasAudio,
+                    frames = savedFrames
+                };
+            }
+            catch (Exception ex) { return new { success = false, error = ex.InnerException?.Message ?? ex.Message }; }
         }
 
         /// <summary>現在フレームをキャプチャしてbase64を返す（Dispatcher内から呼ぶ）</summary>

--- a/claude_desktop_config_example.json
+++ b/claude_desktop_config_example.json
@@ -3,7 +3,9 @@
     "ymm4": {
       "command": "python",
       "args": ["C:/Users/ecrea/OneDrive/デスクトップ/ymm4プラグイン/mcp-server/server.py"],
-      "env": {}
+      "env": {
+        "GEMINI_API_KEY": "ここにGoogle AI StudioのAPIキーを入れる(動画解析機能を使う場合)"
+      }
     }
   }
 }

--- a/mcp-server/gemini_video.py
+++ b/mcp-server/gemini_video.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""
+Gemini を使った動画解析モジュール。
+
+YMM4 MCP サーバーから利用し、以下2つの解析対象に対応する:
+  - 案A: YMM4プレビューを書き出した「連番PNG + 音声WAV」フォルダ
+  - 案B: 取り込み前の元動画ファイル(mp4等)
+
+検出するイベントの種類は AI(Claude) がプロンプトで自由に指定できる。
+未指定時は「映像・音声で起きていることを全て」検出する。
+
+戻り値は常に、タイムスタンプ(秒/ms)付きの構造化イベントリスト。
+呼び出し側(server.py)が FPS を使ってフレーム番号へ変換する。
+
+APIキー:
+  環境変数 GEMINI_API_KEY または GOOGLE_API_KEY から取得する。
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+import time
+from typing import Any, Optional
+
+# google-genai は遅延 import する(未インストールでもサーバー自体は起動できるように)
+_GENAI_IMPORT_ERROR: Optional[str] = None
+try:
+    from google import genai
+    from google.genai import types as genai_types
+except Exception as e:  # pragma: no cover
+    genai = None
+    genai_types = None
+    _GENAI_IMPORT_ERROR = str(e)
+
+
+DEFAULT_MODEL = "gemini-2.5-flash"
+
+# デフォルトの検出指示(イベント全種類)。AIがカスタムプロンプトを渡せば上書きされる。
+DEFAULT_EVENT_INSTRUCTION = (
+    "この動画(または連番フレーム画像と音声)を時系列で精密に解析し、"
+    "起きている出来事を可能な限りすべて検出してください。具体的には次を含みます:\n"
+    "- シーンの切り替わり/カットの変化\n"
+    "- 登場人物・キャラクター・オブジェクトの出現/退場\n"
+    "- 大きな動きやアクション(攻撃、移動、衝突、変形 など)\n"
+    "- 効果音・歓声・BGMの変化・無音→音ありの変化などの音響イベント\n"
+    "- テロップ・文字・UI・数値(スコア/HP等)の表示や変化\n"
+    "- 画面全体の色やフラッシュ、明暗の急変\n"
+    "- その他、実況・解説の見どころになりそうな重要な瞬間"
+)
+
+
+def _get_api_key() -> Optional[str]:
+    return os.environ.get("GEMINI_API_KEY") or os.environ.get("GOOGLE_API_KEY")
+
+
+def is_available() -> tuple[bool, str]:
+    """Gemini解析が利用可能か(SDK導入済み & APIキー設定済み)を返す。"""
+    if genai is None:
+        return False, f"google-genai 未インストール: {_GENAI_IMPORT_ERROR}. `pip install google-genai` を実行してください。"
+    if not _get_api_key():
+        return False, "環境変数 GEMINI_API_KEY (または GOOGLE_API_KEY) が未設定です。"
+    return True, "ok"
+
+
+def _client() -> "genai.Client":
+    return genai.Client(api_key=_get_api_key())
+
+
+def _build_prompt(event_instruction: str) -> str:
+    """イベント検出指示を組み込んだ、JSON出力を強制するプロンプトを作る。"""
+    return (
+        f"{event_instruction}\n\n"
+        "## 出力形式(厳守)\n"
+        "解析結果を以下のJSON **のみ** で返してください。前後に説明文やコードフェンスを付けないこと。\n"
+        "{\n"
+        '  "summary": "動画全体の要約(日本語, 2〜4文)",\n'
+        '  "events": [\n'
+        "    {\n"
+        '      "time_sec": 12.3,                // イベント発生時刻(秒, 小数可)。動画先頭=0。\n'
+        '      "end_sec": 14.0,                 // 終了時刻(継続するイベントのみ。瞬間的ならtime_secと同じでよい)\n'
+        '      "type": "scene_change | character | action | sound | text | color | other",\n'
+        '      "label": "短いラベル(例: 敵キャラ出現)",\n'
+        '      "description": "何が起きたかの説明(日本語)",\n'
+        '      "audio": "その瞬間の音の説明(効果音/歓声/BGM/無音 など。不明ならnull)",\n'
+        '      "importance": 1                  // 1(低)〜5(高) 実況の見どころ度\n'
+        "    }\n"
+        "  ]\n"
+        "}\n\n"
+        "重要: time_sec は必ず動画の先頭を0とした相対秒で答えること。events は時刻昇順で並べること。"
+    )
+
+
+def _extract_json(text: str) -> dict:
+    """Geminiの応答からJSONを頑健に抽出する。コードフェンスや前後テキストを許容。"""
+    if not text:
+        return {"summary": "", "events": [], "_parse_error": "空の応答"}
+    # ```json ... ``` を剥がす
+    fence = re.search(r"```(?:json)?\s*(\{.*?\})\s*```", text, re.DOTALL)
+    candidate = fence.group(1) if fence else None
+    if candidate is None:
+        # 最初の { から最後の } までを取る
+        start = text.find("{")
+        end = text.rfind("}")
+        candidate = text[start : end + 1] if (start >= 0 and end > start) else text
+    try:
+        return json.loads(candidate)
+    except Exception as e:
+        return {"summary": "", "events": [], "_parse_error": f"JSON解析失敗: {e}", "_raw": text[:2000]}
+
+
+def _wait_file_active(client, file_obj, timeout_sec: int = 180):
+    """File API にアップロードした動画が ACTIVE になるまで待つ。"""
+    name = file_obj.name
+    waited = 0
+    while True:
+        f = client.files.get(name=name)
+        state = getattr(f.state, "name", str(f.state))
+        if state == "ACTIVE":
+            return f
+        if state == "FAILED":
+            raise RuntimeError("Geminiでの動画処理に失敗しました(FAILED)")
+        if waited >= timeout_sec:
+            raise TimeoutError(f"動画処理がタイムアウトしました(state={state})")
+        time.sleep(3)
+        waited += 3
+
+
+def analyze_video_file(
+    video_path: str,
+    event_instruction: Optional[str] = None,
+    model: str = DEFAULT_MODEL,
+) -> dict:
+    """
+    【案B】元動画ファイル(mp4等)を直接 Gemini で解析する。
+
+    Gemini の File API に動画をアップロードし、映像+音声を時系列解析させて
+    タイムスタンプ付きイベントJSONを得る。
+    """
+    ok, msg = is_available()
+    if not ok:
+        return {"success": False, "error": msg}
+    if not os.path.isfile(video_path):
+        return {"success": False, "error": f"動画ファイルが見つかりません: {video_path}"}
+
+    instruction = event_instruction or DEFAULT_EVENT_INSTRUCTION
+    client = _client()
+
+    try:
+        uploaded = client.files.upload(file=video_path)
+        active = _wait_file_active(client, uploaded)
+        resp = client.models.generate_content(
+            model=model,
+            contents=[active, _build_prompt(instruction)],
+        )
+        parsed = _extract_json(getattr(resp, "text", "") or "")
+        # 後始末(File APIの容量節約)
+        try:
+            client.files.delete(name=uploaded.name)
+        except Exception:
+            pass
+        return {
+            "success": True,
+            "source": "file",
+            "video_path": video_path,
+            "model": model,
+            **parsed,
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Gemini解析エラー: {e}"}
+
+
+def analyze_frames_dir(
+    frames_dir: str,
+    frames_meta: Optional[list[dict]] = None,
+    audio_path: Optional[str] = None,
+    event_instruction: Optional[str] = None,
+    model: str = DEFAULT_MODEL,
+    max_images: int = 60,
+) -> dict:
+    """
+    【案A】YMM4プレビューを書き出した連番PNG(+音声WAV)フォルダを Gemini で解析する。
+
+    frames_meta は C# の /api/preview/export-clip が返す frames 配列
+    (各要素 {index, frame, timeMs, file, ...})。time_sec とフレーム番号の対応に使う。
+    画像が多すぎる場合は均等間引きして max_images 枚に絞る。
+    """
+    ok, msg = is_available()
+    if not ok:
+        return {"success": False, "error": msg}
+    if not os.path.isdir(frames_dir):
+        return {"success": False, "error": f"フォルダが見つかりません: {frames_dir}"}
+
+    instruction = event_instruction or DEFAULT_EVENT_INSTRUCTION
+    client = _client()
+
+    # 解析対象の画像ファイルを決定(metaがあればそれを優先、なければフォルダ走査)
+    if frames_meta:
+        entries = [m for m in frames_meta if m.get("file")]
+    else:
+        files = sorted(f for f in os.listdir(frames_dir) if f.lower().endswith(".png"))
+        entries = [{"file": f, "timeMs": None, "frame": None} for f in files]
+
+    if not entries:
+        return {"success": False, "error": "解析対象の画像がありません"}
+
+    # 多すぎる場合は均等間引き
+    if len(entries) > max_images:
+        stepf = len(entries) / max_images
+        entries = [entries[int(i * stepf)] for i in range(max_images)]
+
+    # 画像 + 各画像の時刻ラベルを contents に並べる
+    contents: list[Any] = []
+    time_table_lines = []
+    try:
+        for e in entries:
+            path = os.path.join(frames_dir, e["file"])
+            if not os.path.isfile(path):
+                continue
+            with open(path, "rb") as fh:
+                img_bytes = fh.read()
+            contents.append(genai_types.Part.from_bytes(data=img_bytes, mime_type="image/png"))
+            t_ms = e.get("timeMs")
+            t_label = f"{t_ms/1000.0:.2f}s" if isinstance(t_ms, (int, float)) else "?"
+            contents.append(genai_types.Part.from_text(text=f"[上の画像の時刻 = {t_label}, frame={e.get('frame')}]"))
+            time_table_lines.append(f"  画像{len(time_table_lines)}: time={t_label} frame={e.get('frame')}")
+
+        # 音声があれば添付
+        if audio_path and os.path.isfile(audio_path):
+            with open(audio_path, "rb") as fh:
+                wav_bytes = fh.read()
+            contents.append(genai_types.Part.from_bytes(data=wav_bytes, mime_type="audio/wav"))
+            contents.append(genai_types.Part.from_text(
+                text="↑これは上記フレーム区間全体の音声です。画像の時刻と対応付けて音響イベントを解析してください。"))
+
+        # 指示プロンプト
+        contents.append(genai_types.Part.from_text(text=(
+            "上記は、ある動画区間を時刻順にサンプリングした連番フレーム画像"
+            "(各画像の直後にその時刻を示すラベルあり)と、その区間の音声です。\n\n"
+            + _build_prompt(instruction)
+        )))
+
+        resp = client.models.generate_content(model=model, contents=contents)
+        parsed = _extract_json(getattr(resp, "text", "") or "")
+        return {
+            "success": True,
+            "source": "frames_dir",
+            "frames_dir": frames_dir,
+            "analyzed_images": len([c for c in contents if getattr(c, "inline_data", None)]) or len(entries),
+            "model": model,
+            **parsed,
+        }
+    except Exception as e:
+        return {"success": False, "error": f"Gemini解析エラー: {e}"}

--- a/mcp-server/requirements.txt
+++ b/mcp-server/requirements.txt
@@ -1,2 +1,3 @@
 mcp>=1.0.0
 httpx>=0.27.0
+google-genai>=0.3.0

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -20,6 +20,7 @@ YMM4(ゆっくりMovieMaker4)をMCP経由でClaudeから操作するサーバー
 
 import asyncio
 import json
+import os
 import sys
 from typing import Any
 import httpx
@@ -32,6 +33,14 @@ from mcp.types import (
     CallToolResult,
     ListToolsResult,
 )
+
+# Gemini 動画解析モジュール(同フォルダ)
+try:
+    import gemini_video
+except Exception:
+    # server.py が別CWDから起動された場合に備えてパスを通す
+    sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+    import gemini_video  # type: ignore
 
 # YMM4プラグインのHTTP API URL
 YMM4_API_BASE = "http://localhost:8765/api"
@@ -174,6 +183,44 @@ TOOLS = [
             },
             "required": ["action"]
         }
+    ),
+    Tool(
+        name="ymm4_analyze_video",
+        description=(
+            "【Gemini動画解析】動画を時系列で精密に解析し、何が起きているか(シーン変化/キャラ登場/効果音/"
+            "テロップ/動き等)をタイムスタンプ付きで検出する。検出したいイベントは event_instruction で自由にカスタマイズ可能"
+            "(未指定なら全イベントを検出)。\n\n"
+            "2つのモードがある:\n"
+            "- source='preview': YMM4プレビューの指定フレーム区間を連番画像+音声として書き出し、Geminiで解析する。"
+            "タイムラインに配置済みの素材の内容を解析したい時に使う。start_frame/end_frame/step_frames を指定。\n"
+            "- source='file': 取り込み前の元動画ファイル(mp4等)をGeminiに直接渡して解析する。video_path を指定。\n\n"
+            "結果のイベントには time_sec(動画先頭からの秒) と、それを変換した frame(YMM4フレーム番号) が含まれるため、"
+            "そのまま add_script のセリフ配置やイベント同期に使える。\n"
+            "※ 環境変数 GEMINI_API_KEY が必要。"
+        ),
+        inputSchema={
+            "type": "object",
+            "properties": {
+                "source": {
+                    "type": "string",
+                    "enum": ["preview", "file"],
+                    "description": "preview:YMM4プレビュー区間を解析 / file:元動画ファイルを解析"
+                },
+                "event_instruction": {
+                    "type": "string",
+                    "description": "検出したいイベントの指示(日本語可)。例:'効果音とキャラの登場だけ検出して'。省略時は全イベント検出。"
+                },
+                "video_path": {"type": "string", "description": "source='file'時: 解析する動画ファイルの絶対パス"},
+                "start_frame": {"type": "integer", "description": "source='preview'時: 解析開始フレーム(既定0)"},
+                "end_frame": {"type": "integer", "description": "source='preview'時: 解析終了フレーム"},
+                "step_frames": {"type": "integer", "description": "source='preview'時: 何フレームおきにキャプチャするか(既定3。細かくするほど精密だが遅い)"},
+                "record_audio": {"type": "boolean", "description": "source='preview'時: 区間音声も録音して音響イベント解析に使うか(既定true)"},
+                "base_frame": {"type": "integer", "description": "file解析時に time_sec→frame 変換の基準にする開始フレーム(既定0)。検出結果をこのフレーム以降に配置したい時に使う。"},
+                "fps": {"type": "integer", "description": "file解析時のFPS(省略時はYMM4から取得、取得不可なら30)"},
+                "model": {"type": "string", "description": "使用するGeminiモデル(既定 gemini-2.5-flash。高精度には gemini-2.5-pro)"}
+            },
+            "required": ["source"]
+        }
     )
 ]
 
@@ -194,6 +241,9 @@ async def call_tool(name: str, arguments: dict) -> CallToolResult:
             return result
         if name == "ymm4_advanced":
             result = await dispatch_advanced(arguments)
+            return CallToolResult(content=[TextContent(type="text", text=format_result(result))])
+        if name == "ymm4_analyze_video":
+            result = await analyze_video(arguments)
             return CallToolResult(content=[TextContent(type="text", text=format_result(result))])
         if name != "ymm4_interact":
             raise ValueError(f"Unknown tool: {name}")
@@ -429,6 +479,140 @@ async def dispatch_advanced(args: dict) -> Any:
 
         case _:
             raise ValueError(f"Unknown action for ymm4_advanced: {action}")
+
+
+# ============================================================
+# Gemini 動画解析
+# ============================================================
+
+async def ymm4_post_long(path: str, body: dict, timeout: float = 600.0) -> dict:
+    """長時間処理(クリップ書き出し等)用のPOST。タイムアウトを長めに取る。"""
+    async with httpx.AsyncClient(timeout=timeout) as client:
+        res = await client.post(f"{YMM4_API_BASE}{path}", json=body)
+        res.raise_for_status()
+        return res.json()
+
+
+def _sec_to_frame(time_sec: Any, fps: int, base_frame: int) -> Any:
+    """秒 → YMM4フレーム番号に変換する。"""
+    try:
+        return base_frame + int(round(float(time_sec) * fps))
+    except (TypeError, ValueError):
+        return None
+
+
+def _attach_frames(result: dict, fps: int, base_frame: int) -> dict:
+    """Geminiが返したeventsの time_sec/end_sec をフレーム番号に変換して付加する。"""
+    events = result.get("events")
+    if isinstance(events, list):
+        for ev in events:
+            if not isinstance(ev, dict):
+                continue
+            if "time_sec" in ev:
+                ev["frame"] = _sec_to_frame(ev.get("time_sec"), fps, base_frame)
+            if "end_sec" in ev and ev.get("end_sec") is not None:
+                ev["end_frame"] = _sec_to_frame(ev.get("end_sec"), fps, base_frame)
+    result["fps_used"] = fps
+    result["base_frame"] = base_frame
+    return result
+
+
+async def _get_fps_from_ymm4(default: int = 30) -> int:
+    """YMM4プラグインからFPSを取得する。取れなければdefault。"""
+    try:
+        data = await ymm4_get("/project/fps")
+        fps = data.get("fps")
+        if isinstance(fps, int) and fps > 0:
+            return fps
+    except Exception:
+        pass
+    return default
+
+
+async def analyze_video(args: dict) -> dict:
+    """
+    動画をGeminiで解析し、タイムスタンプ+YMM4フレーム番号付きのイベントを返す。
+
+    source='preview': C#の /api/preview/export-clip で区間を連番PNG+WAVに書き出し、
+                      gemini_video.analyze_frames_dir で解析する。
+    source='file'   : gemini_video.analyze_video_file で元動画を直接解析する。
+    """
+    # Geminiが使えるか先にチェック
+    ok, msg = gemini_video.is_available()
+    if not ok:
+        return {
+            "success": False,
+            "error": msg,
+            "hint": "Google AI Studioでキーを発行し、Claude Desktop設定のenvで GEMINI_API_KEY を渡すか、"
+                    "サーバー起動環境で環境変数を設定してください。`pip install google-genai` も必要です。",
+        }
+
+    source = args.get("source")
+    instruction = args.get("event_instruction")  # Noneなら全イベント
+    model = args.get("model") or gemini_video.DEFAULT_MODEL
+
+    if source == "file":
+        video_path = args.get("video_path", "")
+        if not video_path:
+            return {"success": False, "error": "source='file'にはvideo_pathが必要です"}
+        base_frame = int(args.get("base_frame", 0))
+        fps = args.get("fps")
+        if not isinstance(fps, int) or fps <= 0:
+            fps = await _get_fps_from_ymm4(30)
+
+        # Gemini呼び出しはブロッキングなので別スレッドで
+        result = await asyncio.to_thread(
+            gemini_video.analyze_video_file, video_path, instruction, model
+        )
+        if result.get("success"):
+            result = _attach_frames(result, fps, base_frame)
+        return result
+
+    elif source == "preview":
+        start_frame = int(args.get("start_frame", 0))
+        end_frame = int(args.get("end_frame", start_frame + 300))
+        step_frames = int(args.get("step_frames", 3))
+        record_audio = args.get("record_audio", True)
+
+        # 1) C#でプレビュー区間を連番PNG+WAVに書き出す(長時間)
+        try:
+            clip = await ymm4_post_long("/preview/export-clip", {
+                "startFrame": start_frame,
+                "endFrame": end_frame,
+                "stepFrames": step_frames,
+                "recordAudio": record_audio,
+            })
+        except httpx.ConnectError:
+            raise
+        except Exception as e:
+            return {"success": False, "error": f"クリップ書き出し失敗: {e}"}
+
+        if not clip.get("success"):
+            return {"success": False, "error": clip.get("error", "export-clip失敗"), "detail": clip}
+
+        frames_dir = clip.get("outputDir")
+        frames_meta = clip.get("frames", [])
+        audio_path = clip.get("audioFile")
+        fps = clip.get("fps", 30)
+
+        # 2) GeminiでフレームフォルダをN解析(ブロッキング→別スレッド)
+        result = await asyncio.to_thread(
+            gemini_video.analyze_frames_dir,
+            frames_dir, frames_meta, audio_path, instruction, model,
+        )
+        if result.get("success"):
+            # time_sec はクリップ先頭=0 基準なので、base_frame=start_frame で実フレームに戻す
+            result = _attach_frames(result, fps, start_frame)
+            result["clip"] = {
+                "outputDir": frames_dir,
+                "frameCount": clip.get("frameCount"),
+                "audioFile": audio_path,
+                "hasAudio": clip.get("hasAudio"),
+            }
+        return result
+
+    else:
+        return {"success": False, "error": f"不明なsource: {source} (preview または file)"}
 
 
 def format_result(data: Any) -> str:


### PR DESCRIPTION
映像の内容(イベント発生フレーム)をAIが認識し、音声と同期できるよう
Geminiのネイティブ動画理解を組み込んだ。プレビュー(配置済み素材)と
元動画ファイルの両方に対応し、検出イベントはプロンプトでカスタマイズ可能。

新ツール ymm4_analyze_video (Python):
- source='preview': YMM4プレビューの指定フレーム区間を解析
- source='file'   : 元動画ファイル(mp4等)を直接解析
- event_instruction で検出イベントを自由指定(未指定なら全イベント検出)
- 戻り値のイベントに time_sec と、FPSから変換した frame/end_frame を付加
  → add_scriptのセリフ配置やイベント同期にそのまま使える

C# (McpHttpServer.cs):
- POST /api/preview/export-clip: プレビュー区間を連番PNG+音声WAVで ディスクに書き出す。録音時は実時間ベース、非録音時はSeekベースで 各フレームをキャプチャ。フレーム数上限・FPS自動取得つき。
- GET  /api/project/fps: FPS・解像度を取得(時刻→フレーム変換の基準)

Python:
- gemini_video.py を新設(解析ロジックを分離)
  - analyze_video_file: File APIに動画をアップロード→ACTIVE待ち→解析→後始末
  - analyze_frames_dir: 連番PNG+各フレームの時刻ラベル+音声WAVを渡して解析 画像が多い場合は均等間引き(既定60枚上限)
  - JSON出力を強制するプロンプト・頑健なJSON抽出(コードフェンス許容)
  - google-genai未導入/APIキー未設定でもサーバーは起動し案内を返す
- server.py: ymm4_analyze_video ツール定義・ディスパッチ・FPS取得・ 秒→フレーム変換(_sec_to_frame/_attach_frames)・長時間用HTTPクライアント
- requirements.txt: google-genai を追加
- claude_desktop_config_example.json: env に GEMINI_API_KEY を追記

設計: 全フレームをClaudeに投げず、重い解析はGeminiに集約。Claudeは
構造化済みイベントを受け取り台本化に専念(コンテキスト・コスト効率)。

README: 動画解析機能の仕組み・2モード・カスタマイズ・戻り値例・
セットアップ手順を追記。